### PR TITLE
Add Tags & Informer in standart text field

### DIFF
--- a/example/lib/screens/standart_textfield_screen.dart
+++ b/example/lib/screens/standart_textfield_screen.dart
@@ -152,7 +152,7 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
                     children: <Widget>[
                       for (int i = 0; i < 10; i++)
                         Row(
-                          children: [
+                          children: <Widget>[
                             TagControlWidget(
                               trailingImage:
                                   AdmiralIcons.admiral_ic_heart_solid,

--- a/example/lib/screens/standart_textfield_screen.dart
+++ b/example/lib/screens/standart_textfield_screen.dart
@@ -25,8 +25,8 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
   FocusNode secureFocusNode = FocusNode();
   TextInputState state = TextInputState.normal;
   TextEditingController textController = TextEditingController(text: 'Text');
-  TextEditingController secureTextController = 
-  TextEditingController(text: 'Text');
+  TextEditingController secureTextController =
+      TextEditingController(text: 'Text');
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +90,7 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
                 height: LayoutGrid.module * 5,
               ),
               TitleHeaderWidget(
-                title: 'Basic', 
+                title: 'Basic',
                 style: TitleHeaderStyle.headlineSecondary,
                 textAlign: TextAlign.left,
                 isEnable: isEnabled,
@@ -110,7 +110,7 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
                 height: LayoutGrid.module * 5,
               ),
               TitleHeaderWidget(
-                title: 'Masked', 
+                title: 'Masked',
                 style: TitleHeaderStyle.headlineSecondary,
                 textAlign: TextAlign.left,
                 isEnable: isEnabled,
@@ -126,6 +126,47 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
                 placeHolderText: 'Placeholder',
                 informerText: 'Additional text',
                 hasSecure: true,
+              ),
+              SizedBox(
+                height: LayoutGrid.module * 5,
+              ),
+              TitleHeaderWidget(
+                title: '+ Tags & Informer',
+                style: TitleHeaderStyle.headlineSecondary,
+                textAlign: TextAlign.left,
+                isEnable: isEnabled,
+              ),
+              SizedBox(
+                height: LayoutGrid.module * 5,
+              ),
+              TextFieldWidget(
+                secureTextController,
+                state: state,
+                focusNode: secureFocusNode,
+                labelText: 'Optional label',
+                placeHolderText: 'Placeholder',
+                bottomWidget: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: <Widget>[
+                      for (int i = 0; i < 10; i++)
+                        Row(
+                          children: [
+                            TagControlWidget(
+                              trailingImage:
+                                  AdmiralIcons.admiral_ic_heart_solid,
+                              title: 'Text',
+                              style: TagStyle.normal,
+                              isEnabled: isEnabled,
+                            ),
+                            if (i != 9) SizedBox(width: LayoutGrid.module),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+                informerText: 'Additional text',
               ),
             ],
           ),

--- a/example/lib/screens/standart_textfield_screen.dart
+++ b/example/lib/screens/standart_textfield_screen.dart
@@ -145,6 +145,7 @@ class _StandartTextFieldScreenState extends State<StandartTextFieldScreen> {
                 focusNode: secureFocusNode,
                 labelText: 'Optional label',
                 placeHolderText: 'Placeholder',
+                trailingIcon: Icon(AdmiralIcons.admiral_ic_info_outline),
                 bottomWidget: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: Row(

--- a/lib/src/widgets/views/textfields/textfield/textfield.dart
+++ b/lib/src/widgets/views/textfields/textfield/textfield.dart
@@ -182,10 +182,8 @@ class _TextFieldState extends State<TextFieldWidget>
           isEditing: _hasFocus,
         ),
         if (widget.bottomWidget != null)
-          SizedBox(
-            height: LayoutGrid.halfModule * 10,
-            child: widget.bottomWidget,
-          ),
+          const SizedBox(height: LayoutGrid.module),
+        Container(child: widget.bottomWidget),
         const SizedBox(height: LayoutGrid.module),
         if (widget.informerText != null &&
             widget.informerText?.isEmpty == false)

--- a/lib/src/widgets/views/textfields/textfield/textfield.dart
+++ b/lib/src/widgets/views/textfields/textfield/textfield.dart
@@ -15,7 +15,9 @@ class TextFieldWidget extends StatefulWidget {
     this.informerText,
     this.placeHolderText = '',
     this.hasSecure,
+    this.trailingIcon,
     this.bottomWidget,
+    this.onTrailingTap,
     this.onChanged,
     this.onEditingComplete,
     this.scheme,
@@ -31,10 +33,12 @@ class TextFieldWidget extends StatefulWidget {
   final String? informerText;
   final String placeHolderText;
   final bool? hasSecure;
+  final Icon? trailingIcon;
   final Widget? bottomWidget;
 
   final ValueChanged<String>? onChanged;
   final VoidCallback? onEditingComplete;
+  final VoidCallback? onTrailingTap;
   final TextFieldScheme? scheme;
 
   @override
@@ -172,6 +176,23 @@ class _TextFieldState extends State<TextFieldWidget>
                             color:
                                 scheme.iconColor.unsafeParameter(widget.state),
                           ),
+                  ),
+                ),
+              ),
+            if (widget.trailingIcon != null)
+              AbsorbPointer(
+                absorbing: widget.state == TextInputState.disabled,
+                child: GestureDetector(
+                  onTap: () {
+                    widget.onTrailingTap?.call();
+                  },
+                  child: SizedBox(
+                    height: LayoutGrid.quadrupleModule,
+                    width: LayoutGrid.quadrupleModule,
+                    child: Icon(
+                      widget.trailingIcon?.icon,
+                      color: scheme.iconColor.unsafeParameter(widget.state),
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Что было сделано
Tags & Informer in standart text field
<img width="371" alt="Снимок экрана 2024-01-29 в 19 39 15" src="https://github.com/admiral-team/admiralui-flutter/assets/66259778/39e1a87e-52e2-4f8e-a133-5946a9df27aa">

