### PR TITLE
[445] - Fix init state for circular & linear page controll

### DIFF
--- a/example/lib/screens/pageControls/circle/page_control_circle_screen.dart
+++ b/example/lib/screens/pageControls/circle/page_control_circle_screen.dart
@@ -20,7 +20,7 @@ class PageControlCircleScreen extends StatefulWidget {
 
 class _PageControlCircleScreenState extends State<PageControlCircleScreen> {
   SpinnerSize spinnerSize = SpinnerSize.small;
-  final ValueNotifier<int> _countNotifier = ValueNotifier<int>(1);
+  final ValueNotifier<int> _countNotifier = ValueNotifier<int>(3);
 
   final List<String> tabItems = <String>[
     'One',
@@ -65,9 +65,9 @@ class _PageControlCircleScreenState extends State<PageControlCircleScreen> {
             children: <Widget>[
               OutlineTabs.withStringItems(
                 tabItems,
+                selectedIndex: 2,
                 onSelected: (int index) {
                   setState(() {
-                    print(index + 1);
                     _countNotifier.value = index + 1;
                   });
                 },

--- a/example/lib/screens/pageControls/linear/page_control_linear_screen.dart
+++ b/example/lib/screens/pageControls/linear/page_control_linear_screen.dart
@@ -32,7 +32,7 @@ class _PageControlLinearScreenState extends State<PageControlLinearScreen> {
     OutlineTabItem('Seven'),
   ];
 
-  int _countStep = 1;
+  int _countStep = 4;
 
   @override
   Widget build(BuildContext context) {
@@ -69,6 +69,7 @@ class _PageControlLinearScreenState extends State<PageControlLinearScreen> {
             children: <Widget>[
               OutlineTabs(
                 tabItems,
+                selectedIndex: _countStep - 1,
                 onSelected: (int index) {
                   setState(() {
                     _countStep = index + 1;

--- a/lib/src/widgets/tabs/outline_tabs/outline_tabs.dart
+++ b/lib/src/widgets/tabs/outline_tabs/outline_tabs.dart
@@ -70,6 +70,7 @@ import 'package:flutter/material.dart';
 class OutlineTabs extends StatefulWidget {
   const OutlineTabs(
     this.tabs, {
+    this.selectedIndex = 0,
     this.isEnabled = true,
     this.onSelected,
     this.scheme,
@@ -79,6 +80,7 @@ class OutlineTabs extends StatefulWidget {
 
   factory OutlineTabs.withStringItems(
     List<String> tabTitles, {
+    int selectedIndex = 0,
     bool isEnabled = true,
     ValueChanged<int>? onSelected,
     OutlineTabsScheme? scheme,
@@ -89,6 +91,7 @@ class OutlineTabs extends StatefulWidget {
         tabTitles.map((String title) => OutlineTabItem(title)).toList();
     return OutlineTabs(
       tabItems,
+      selectedIndex: selectedIndex,
       isEnabled: isEnabled,
       onSelected: onSelected,
       scheme: scheme,
@@ -98,6 +101,7 @@ class OutlineTabs extends StatefulWidget {
   }
 
   final List<OutlineTabItem> tabs;
+  final int selectedIndex;
   final bool isEnabled;
   final double horizontalPadding;
   final OutlineTabsScheme? scheme;
@@ -109,8 +113,8 @@ class OutlineTabs extends StatefulWidget {
 
 class _OutlineTabsState extends State<OutlineTabs>
     with SingleTickerProviderStateMixin {
-  int currentPos = 0;
   late OutlineTabsScheme scheme;
+  late int currentStep = widget.selectedIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -142,10 +146,10 @@ class _OutlineTabsState extends State<OutlineTabs>
                     splashColor: Colors.transparent,
                     onTap: () {
                       setState(() {
-                        currentPos = i;
+                        currentStep = i;
                         if (widget.onSelected != null) {
                           setState(() {
-                            widget.onSelected!(currentPos);
+                            widget.onSelected!(currentStep);
                           });
                         }
                       });
@@ -154,7 +158,7 @@ class _OutlineTabsState extends State<OutlineTabs>
                       height: LayoutGrid.quadrupleModule,
                       decoration: BoxDecoration(
                         border: Border.all(
-                          color: currentPos == i
+                          color: currentStep == i
                               ? selectedBorderColor
                               : borderColor,
                           width: LayoutGrid.halfModule / 2,
@@ -176,7 +180,7 @@ class _OutlineTabsState extends State<OutlineTabs>
                                     const EdgeInsets.symmetric(horizontal: 16),
                                 child: TextView(
                                   widget.tabs[i].text,
-                                  style: currentPos == i
+                                  style: currentStep == i
                                       ? scheme.textFont.toTextStyle(textColor)
                                       : scheme.unselectedTextFont
                                           .toTextStyle(textColor),


### PR DESCRIPTION
# Задача
Для Circle индикатора зададим изначальное состояние 3
ОР
<img width="323" alt="Снимок экрана 2024-03-12 в 10 43 34" src="https://github.com/admiral-team/admiralui-flutter/assets/8963238/326dd88e-be83-4573-84c9-d715870b5535">
ФР
![Simulator Screenshot - iPhone 15 - 2024-03-12 at 10 43 51](https://github.com/admiral-team/admiralui-flutter/assets/8963238/b6ac9506-5214-4405-a519-5a4655d33c0f)

Closes #445


## Что было сделано

## Что необходимо протестировать

## Скриншоты(optional)

https://github.com/admiral-team/admiralui-flutter/assets/66259778/a7700003-e41e-423b-bafa-f3d2fce6f85d

