### PR TITLE
[446] - Fix titles for page control and alerts

### DIFF
--- a/example/lib/screens/alerts_screen.dart
+++ b/example/lib/screens/alerts_screen.dart
@@ -43,66 +43,69 @@ class AlertsScreen extends StatelessWidget {
     final FontPalette fonts = theme.fonts;
 
     return Scaffold(
-      extendBodyBehindAppBar: true,
+      backgroundColor: colors.backgroundBasic.color(),
       appBar: AppBar(
         leading: BackButton(
           onPressed: () => Navigator.of(context).pop(),
         ),
         bottomOpacity: 0.0,
         elevation: 0.0,
-        backgroundColor: colors.backgroundBasic.color(),
-        title: Text(
-          title,
-          style: fonts.largeTitle1.toTextStyle(
-            colors.textPrimary.color(),
-          ),
-        ),
       ),
-      body: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: LayoutGrid.doubleModule,
-        ),
-        color: colors.backgroundBasic.color(),
-        child: ListView.separated(
-          addAutomaticKeepAlives: false,
-          addRepaintBoundaries: false,
-          physics: const BouncingScrollPhysics(
-            parent: AlwaysScrollableScrollPhysics(),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(LayoutGrid.doubleModule),
+            child: TextView(
+              title,
+              font: fonts.title1,
+              textColorNormal: colors.textPrimary.color(),
+            ),
           ),
-          itemCount: items.length,
-          itemBuilder: (BuildContext ctx, int index) {
-            final ListCellModel? item =
-                index == items.length ? null : items[index];
-            if (item is ListCellModel) {
-              return BaseCellWidget(
-                centerCell: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      item.title,
-                      style: fonts.body1.toTextStyle(
-                        colors.textPrimary.color(),
-                      ),
+          Expanded(
+            child: ListView.separated(
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              physics: const BouncingScrollPhysics(
+                parent: AlwaysScrollableScrollPhysics(),
+              ),
+              itemCount: items.length,
+              itemBuilder: (BuildContext ctx, int index) {
+                final ListCellModel? item =
+                    index == items.length ? null : items[index];
+                if (item is ListCellModel) {
+                  return BaseCellWidget(
+                    centerCell: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(
+                          item.title,
+                          style: fonts.body1.toTextStyle(
+                            colors.textPrimary.color(),
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                trailingCell: Icon(
-                  AdmiralIcons.admiral_ic_chevron_right_outline,
-                  color: colors.elementSecondary.color(),
-                ),
-                onPressed: item.onPressed,
-              );
-            }
-            return Container();
-          },
-          separatorBuilder: (
-            BuildContext ctx,
-            int index,
-          ) {
-            return Container();
-          },
-        ),
+                    trailingCell: Icon(
+                      AdmiralIcons.admiral_ic_chevron_right_outline,
+                      color: colors.elementSecondary.color(),
+                    ),
+                    onPressed: item.onPressed,
+                  );
+                }
+                return Container();
+              },
+              separatorBuilder: (
+                BuildContext ctx,
+                int index,
+              ) {
+                return Container();
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/example/lib/screens/pageControls/page_controls_screen.dart
+++ b/example/lib/screens/pageControls/page_controls_screen.dart
@@ -33,66 +33,69 @@ class PageControlsScreen extends StatelessWidget {
     final FontPalette fonts = theme.fonts;
 
     return Scaffold(
-      extendBodyBehindAppBar: true,
+      backgroundColor: colors.backgroundBasic.color(),
       appBar: AppBar(
         leading: BackButton(
           onPressed: () => Navigator.of(context).pop(),
         ),
         bottomOpacity: 0.0,
         elevation: 0.0,
-        backgroundColor: colors.backgroundBasic.color(),
-        title: Text(
-          title,
-          style: fonts.largeTitle1.toTextStyle(
-            colors.textPrimary.color(),
-          ),
-        ),
       ),
-      body: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: LayoutGrid.doubleModule,
-        ),
-        color: colors.backgroundBasic.color(),
-        child: ListView.separated(
-          addAutomaticKeepAlives: false,
-          addRepaintBoundaries: false,
-          physics: const BouncingScrollPhysics(
-            parent: AlwaysScrollableScrollPhysics(),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(LayoutGrid.doubleModule),
+            child: TextView(
+              title,
+              font: fonts.title1,
+              textColorNormal: colors.textPrimary.color(),
+            ),
           ),
-          itemCount: items.length,
-          itemBuilder: (BuildContext ctx, int index) {
-            final ListCellModel? item =
-                index == items.length ? null : items[index];
-            if (item is ListCellModel) {
-              return BaseCellWidget(
-                centerCell: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      item.title,
-                      style: fonts.body1.toTextStyle(
-                        colors.textPrimary.color(),
-                      ),
+          Expanded(
+            child: ListView.separated(
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              physics: const BouncingScrollPhysics(
+                parent: AlwaysScrollableScrollPhysics(),
+              ),
+              itemCount: items.length,
+              itemBuilder: (BuildContext ctx, int index) {
+                final ListCellModel? item =
+                    index == items.length ? null : items[index];
+                if (item is ListCellModel) {
+                  return BaseCellWidget(
+                    centerCell: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(
+                          item.title,
+                          style: fonts.body1.toTextStyle(
+                            colors.textPrimary.color(),
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                trailingCell: Icon(
-                  AdmiralIcons.admiral_ic_chevron_right_outline,
-                  color: colors.elementSecondary.color(),
-                ),
-                onPressed: item.onPressed,
-              );
-            }
-            return Container();
-          },
-          separatorBuilder: (
-            BuildContext ctx,
-            int index,
-          ) {
-            return Container();
-          },
-        ),
+                    trailingCell: Icon(
+                      AdmiralIcons.admiral_ic_chevron_right_outline,
+                      color: colors.elementSecondary.color(),
+                    ),
+                    onPressed: item.onPressed,
+                  );
+                }
+                return Container();
+              },
+              separatorBuilder: (
+                BuildContext ctx,
+                int index,
+              ) {
+                return Container();
+              },
+            ),
+          )
+        ],
       ),
     );
   }


### PR DESCRIPTION
# Задача
Не правильный тайтл должен быть "Alerts & Onboarding"
Не правильная визуализация

ФР
![Simulator Screenshot - iPhone 15 - 2024-03-12 at 11 38 43](https://github.com/admiral-team/admiralui-flutter/assets/8963238/65b6b2ed-9995-4f4e-806f-8b0b3eea348b)
ОР
<img width="359" alt="Снимок экрана 2024-03-12 в 11 38 58" src="https://github.com/admiral-team/admiralui-flutter/assets/8963238/5863e25a-1e00-45fc-a526-9937bb5e2c16">


Closes #446


## Что было сделано

## Что необходимо протестировать

## Скриншоты(optional)
<img width="361" alt="Снимок экрана 2024-03-15 в 17 33 49" src="https://github.com/admiral-team/admiralui-flutter/assets/66259778/ba842824-a354-42d6-874e-28fe9b1df3e9">
<img width="353" alt="Снимок экрана 2024-03-15 в 17 33 59" src="https://github.com/admiral-team/admiralui-flutter/assets/66259778/d4cd64e9-adf7-475a-af13-fc5d03805cbe">
