### PR TITLE
[489] - Fix background Color for Badge

### DIFF
--- a/example/lib/screens/badges/normal_badges_screen.dart
+++ b/example/lib/screens/badges/normal_badges_screen.dart
@@ -27,6 +27,7 @@ class _NormalBadgesScreenState extends State<NormalBadgesScreen> {
     final FontPalette fonts = theme.fonts;
 
     return Scaffold(
+      backgroundColor: colors.backgroundBasic.color(),
       appBar: AppBar(
         leading: BackButton(
           onPressed: () => Navigator.of(context).pop(),


### PR DESCRIPTION
# Задача
Поправить темню тему для экрана Badges
ФР
![normal_badges_dark_disabled_screen_iPhone SE](https://github.com/admiral-team/admiralui-flutter/assets/8963238/6deb8d59-60b7-4578-952b-224172048850)

Closes #489


## Что было сделано

## Что необходимо протестировать

## Скриншоты(optional)
<img width="365" alt="Снимок экрана 2024-04-02 в 13 52 04" src="https://github.com/admiral-team/admiralui-flutter/assets/66259778/c9a07bc7-c691-486e-b547-363d8aa45ad7">
