### PR TITLE
[561] - Fix vertical calendar

### DIFF
--- a/example/lib/screens/calendar/horizontal/calendar_vertical_screen.dart
+++ b/example/lib/screens/calendar/horizontal/calendar_vertical_screen.dart
@@ -54,7 +54,7 @@ class _CalendarVerticalScreenState extends State<CalendarVerticalScreen> {
               selectedEndDate: null,
               selectedStartDate: null,
               startDate: DateTime(2022, 1, 1, 0, 0, 0),
-              currentDate: DateTime(2022, 4, 1, 0, 0, 0),
+              currentDate: DateTime(2022, 1, 1, 0, 0, 0),
               endDate: DateTime(2022, 4, 1, 0, 0, 0),
               onChangedRangeDates: (List<DateTime?> datesRange) {
                 print('Dates range $datesRange');

--- a/lib/src/widgets/views/calendar/dates_data_source/calendar_dates_data_source.dart
+++ b/lib/src/widgets/views/calendar/dates_data_source/calendar_dates_data_source.dart
@@ -79,7 +79,7 @@ class CalendarDatesDataSource {
 
   int getDayMonthDifferenceCount(DateTime date, DateTime? secondDate) {
     final int days = date.difference(secondDate ?? DateTime.now()).inDays;
-    final int months = days ~/ 30;
+    final int months = days ~/ 29;
     return months.abs();
   }
 

--- a/lib/src/widgets/views/calendar/vertical/calendar_vertical_view.dart
+++ b/lib/src/widgets/views/calendar/vertical/calendar_vertical_view.dart
@@ -91,32 +91,12 @@ class _CalendarVerticalViewState extends State<CalendarVerticalView> {
         return Expanded(
           child: CustomScrollView(
             controller: _scrollController,
+            center: _centerKey,
             slivers: <Widget>[
               if (widget.startDate != null && widget.endDate != null)
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) {
-                      if (dataSource.getMonthInRangeOfStatedEndDate(index) !=
-                          null) {
-                        return CalendarVerticalPageView(
-                          dataSource.getMonthInRangeOfStatedEndDate(index)!,
-                          locale,
-                          onTap: (DateTime? date) => setState(
-                            () {
-                              dataSource.didTapAtDate(date);
-                            },
-                          ),
-                          scheme: scheme.pageViewScheme,
-                        );
-                      }
-                      return null;
-                    },
-                    childCount: dataSource.getDayMonthDifferenceCount(
-                      widget.startDate!,
-                      widget.endDate,
-                    ),
-                  ),
-                ),
+                buildStartToCurrentDateList(),
+              buildCurrenDatetList(),
+              buildCurrentToEndList(),
             ],
           ),
         );
@@ -168,33 +148,13 @@ class _CalendarVerticalViewState extends State<CalendarVerticalView> {
             controller: _scrollController,
             center: _centerKey,
             slivers: <Widget>[
-              if (widget.startDate != null)
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) {
-                      return CalendarVerticalPageView(
-                        dataSource.getMonth(index == 0 ? -1 : -(index + 1)),
-                        locale,
-                        onTap: (DateTime? date) => setState(
-                          () {
-                            dataSource.didTapAtDate(date);
-                          },
-                        ),
-                        scheme: scheme.pageViewScheme,
-                      );
-                    },
-                    childCount: dataSource.getDayMonthDifferenceCount(
-                      widget.startDate!,
-                      null,
-                    ),
-                  ),
-                ),
+              if (widget.startDate != null) buildStartToCurrentDateList(),
+              buildCurrenDatetList(),
               SliverList(
-                key: _centerKey,
                 delegate: SliverChildBuilderDelegate(
                   (BuildContext context, int index) {
                     return CalendarVerticalPageView(
-                      dataSource.getMonth(index),
+                      dataSource.getMonth(index + 1),
                       locale,
                       onTap: (DateTime? date) => setState(
                         () {
@@ -212,7 +172,6 @@ class _CalendarVerticalViewState extends State<CalendarVerticalView> {
       case CalendarScrollState.fixedEnd:
         return Expanded(
           child: CustomScrollView(
-            reverse: true,
             controller: _scrollController,
             center: _centerKey,
             slivers: <Widget>[
@@ -221,7 +180,7 @@ class _CalendarVerticalViewState extends State<CalendarVerticalView> {
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
                       return CalendarVerticalPageView(
-                        dataSource.getMonth(index + 1),
+                        dataSource.getMonth(index == 0 ? -1 : -(index + 1)),
                         locale,
                         onTap: (DateTime? date) => setState(
                           () {
@@ -231,32 +190,80 @@ class _CalendarVerticalViewState extends State<CalendarVerticalView> {
                         scheme: scheme.pageViewScheme,
                       );
                     },
-                    childCount: dataSource.getDayMonthDifferenceCount(
-                      widget.endDate!,
-                      null,
-                    ),
                   ),
                 ),
-              SliverList(
-                key: _centerKey,
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) {
-                    return CalendarVerticalPageView(
-                      dataSource.getMonth(index == 0 ? 0 : -index),
-                      locale,
-                      onTap: (DateTime? date) => setState(
-                        () {
-                          dataSource.didTapAtDate(date);
-                        },
-                      ),
-                      scheme: scheme.pageViewScheme,
-                    );
-                  },
-                ),
-              ),
+              buildCurrenDatetList(),
+              buildCurrentToEndList(),
             ],
           ),
         );
     }
+  }
+
+  Widget buildCurrenDatetList() {
+    return SliverList(
+      key: _centerKey,
+      delegate: SliverChildBuilderDelegate(
+        childCount: 1,
+        (BuildContext context, int index) {
+          return CalendarVerticalPageView(
+            dataSource.getMonth(index),
+            locale,
+            onTap: (DateTime? date) => setState(
+              () {
+                dataSource.didTapAtDate(date);
+              },
+            ),
+            scheme: scheme.pageViewScheme,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget buildStartToCurrentDateList() {
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        childCount: dataSource.getDayMonthDifferenceCount(
+          widget.startDate!,
+          widget.currentDate ?? DateTime.now(),
+        ),
+        (BuildContext context, int index) {
+          return CalendarVerticalPageView(
+            dataSource.getMonth(index == 0 ? -1 : -(index + 1)),
+            locale,
+            onTap: (DateTime? date) => setState(
+              () {
+                dataSource.didTapAtDate(date);
+              },
+            ),
+            scheme: scheme.pageViewScheme,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget buildCurrentToEndList() {
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        childCount: dataSource.getDayMonthDifferenceCount(
+          widget.currentDate ?? DateTime.now(),
+          widget.endDate,
+        ),
+        (BuildContext context, int index) {
+          return CalendarVerticalPageView(
+            dataSource.getMonth(index + 1),
+            locale,
+            onTap: (DateTime? date) => setState(
+              () {
+                dataSource.didTapAtDate(date);
+              },
+            ),
+            scheme: scheme.pageViewScheme,
+          );
+        },
+      ),
+    );
   }
 }


### PR DESCRIPTION
# Задача
Если выставить вот такие даты у календаря

CalendarHorizontalView(
          startDate: DateTime(2022, 1, 1, 0, 0, 0),
          endDate: DateTime(2022, 4, 1, 0, 0, 0),
          currentDate: DateTime(2022, 4, 1, 0, 0, 0),

То вертикальный календарь доказывает дату 1 января 2022 года, а должен показать апрель

В горизонтальном календаре при так же параметрах, месяц показывается правильно, но почему то дата 1 апреля селекнутая
![Simulator Screenshot - iPhone 15 - 2024-05-16 at 00 04 24](https://github.com/admiral-team/admiralui-flutter/assets/8963238/5a8faf6e-7797-4341-85b0-0784385bab2f)

Closes #561


## Что было сделано

## Что необходимо протестировать

## Скриншоты(optional)
<img width="797" alt="Снимок экрана 2024-06-18 в 13 25 22" src="https://github.com/admiral-team/admiralui-flutter/assets/66259778/ca4e313d-27f0-4b74-adf1-0d26e3508661">

https://github.com/admiral-team/admiralui-flutter/assets/66259778/6ee31ed5-f103-4bbc-9f8d-51027c332ef4

