### PR TITLE
[594] - Экран настроек

### DIFF
--- a/example/lib/navigation/tab_navigation_setting.dart
+++ b/example/lib/navigation/tab_navigation_setting.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../screens/setting_screen.dart';
+
+enum TabNavigatorSettingRoutes {
+  home('/');
+
+  const TabNavigatorSettingRoutes(this.value);
+  final String value;
+}
+
+class TabNavigatorSetting extends StatelessWidget {
+  const TabNavigatorSetting({
+    super.key,
+    required this.navigatorKey,
+  });
+
+  final GlobalKey<NavigatorState>? navigatorKey;
+
+  void _push(BuildContext context, TabNavigatorSettingRoutes route) {
+    final Map<String, WidgetBuilder> routeBuilders = _routeBuilders(context);
+
+    Navigator.push(
+      context,
+      MaterialPageRoute<Map<String, WidgetBuilder>>(
+        builder: (BuildContext context) => routeBuilders[route.value]!(context),
+      ),
+    );
+  }
+
+  Map<String, WidgetBuilder> _routeBuilders(BuildContext context) {
+    return <String, WidgetBuilder>{
+      TabNavigatorSettingRoutes.home.value: (BuildContext context) => 
+      SettingScreen(
+            title: 'Настройки',
+            onPush: (TabNavigatorSettingRoutes route) => _push(context, route),
+      ),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, WidgetBuilder> routeBuilders = _routeBuilders(context);
+
+    return Navigator(
+      key: navigatorKey,
+      initialRoute: TabNavigatorSettingRoutes.home.value,
+      onGenerateRoute: (RouteSettings routeSettings) {
+        return MaterialPageRoute<Map<String, WidgetBuilder>>(
+          builder: (BuildContext context) =>
+              routeBuilders[routeSettings.name]!(context),
+        );
+      },
+    );
+  }
+}

--- a/example/lib/screens/root_screen.dart
+++ b/example/lib/screens/root_screen.dart
@@ -7,6 +7,7 @@ import '../navigation/tab_navigator_home.dart';
 import '../navigation/tab_navigator_process.dart';
 import '../navigation/tab_navigator_chat.dart';
 import '../storage/app_theme_storage.dart';
+import '../navigation/tab_navigation_setting.dart';
 
 class RootScreen extends StatefulWidget {
   const RootScreen({super.key});
@@ -101,7 +102,7 @@ class _RootScreenState extends State<RootScreen> {
       case TabItem.settings:
         return Offstage(
           offstage: _currentTab != tabItem,
-          child: TabNavigatorProcess(navigatorKey: _navigatorKeys[tabItem]),
+          child: TabNavigatorSetting(navigatorKey: _navigatorKeys[tabItem]),
         );
       case TabItem.info:
         return Offstage(

--- a/example/lib/screens/setting_screen.dart
+++ b/example/lib/screens/setting_screen.dart
@@ -1,0 +1,76 @@
+import 'package:admiralui_flutter/admiralui_flutter.dart';
+import 'package:admiralui_flutter/layout/layout_grid.dart';
+import '../navigation/tab_navigation_setting.dart';
+import 'package:flutter/material.dart';
+
+class SettingScreen extends StatefulWidget {
+  const SettingScreen({
+    super.key,
+    required this.title,
+    required this.onPush,
+  });
+
+  final String title;
+  final Function(TabNavigatorSettingRoutes route) onPush;
+
+  @override
+  State<SettingScreen> createState() => _SettingScreenState();
+}
+
+class _SettingScreenState extends State<SettingScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final AppTheme theme = AppThemeProvider.of(context);
+    final ColorPalette colors = theme.colors;
+    final FontPalette fonts = theme.fonts;
+
+    return Scaffold(
+      backgroundColor: colors.backgroundBasic.color(),
+      appBar: AppBar(
+        elevation: 0,
+        toolbarHeight: LayoutGrid.module * 10,
+        backgroundColor: colors.backgroundBasic.color(),
+        title: Text(
+          widget.title,
+          style: fonts.largeTitle1.toTextStyle(
+            colors.textPrimary.color(),
+          ),
+        ),
+      ),
+      body: Container(
+        color: colors.backgroundBasic.color(),
+        child: Material(
+            color: colors.backgroundBasic.color(),
+            child: SingleChildScrollView(
+                physics: BouncingScrollPhysics(),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    BaseCellWidget(
+                      centerCell: TitleCellWidget(
+                        title: 'Переключить тему',
+                      ),
+                      trailingCell: Switcher(
+                        onChanged: (bool isChecked) {
+                          setState(() {
+                            changeTheme();
+                          });
+                        },
+                      ),
+                      horizontalPadding: LayoutGrid.doubleModule,
+                    ),
+                  ],
+                ))),
+      ),
+    );
+  }
+
+  void changeTheme() {
+    setState(() {
+      final AppThemeProviderWrapperState wrapper =
+          AppThemeProviderWrapper.of(context);
+      wrapper.updateTheme();
+    });
+  }
+}


### PR DESCRIPTION
# Задача
Пустой экран настройки
Вместо переключение swiftui -> переключение темы

<img width="249" alt="Снимок экрана 2024-06-04 в 20 04 35" src="https://github.com/admiral-team/admiralui-flutter/assets/8963238/5908e327-7646-45e8-b6b1-f308f9b1e692">
https://www.figma.com/design/SDunEMSNR5pm4ijiDGvWR9/Admiral-Mobile-%E2%80%A8Application-new?node-id=103903-70285&t=emu1p8KonNSlXOc5-0
Closes #594


## Что было сделано

## Что необходимо протестировать

## Скриншоты(optional)
